### PR TITLE
Update GN_cities.txt

### DIFF
--- a/Assets/Resources/Geographical/cities/GN_cities.txt
+++ b/Assets/Resources/Geographical/cities/GN_cities.txt
@@ -5204,9 +5204,9 @@ Tolo
 Tolomissa
 Toly
 Tomandou
-Tomba Dougoula
-Tomba Foulah
-Tomba
+Tomba kanssa 
+Tomba doula 
+Tomba kobila 
 Tombadonkea
 Tombadou
 Tombaguia Foula


### PR DESCRIPTION
Correction des noms des villages en Guinee qui sont incorrecte  Tomba dougoula=tomba kanssa 
Tomba=tomba kobila 
Tomba foulah=tomba doula @p-svacha 